### PR TITLE
Library is rather slow for realistic files

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "whatwg-url": "^8.0.0"
   },
   "devDependencies": {
+    "benny": "^3.6.15",
     "eslint": "^6.8.0",
     "jest": "^25.1.0",
     "node-fetch": "^2.6.0"

--- a/scripts/bench.js
+++ b/scripts/bench.js
@@ -1,0 +1,32 @@
+"use strict";
+
+const b = require("benny");
+const { readFileSync } = require("fs");
+const parseDataUrl = require("..");
+
+const EXAMPLE = `data:text/plain;base64,` + readFileSync(`${__dirname}/../yarn.lock`, { encoding: "base64" });
+
+const REGEX = /^data:([^;]+);base64,(.*)/;
+function quickNDirty(url) {
+  const [, mime, base] = url.match(REGEX);
+  return { mime, body: Buffer.from(base, "base64") };
+}
+
+const lib = parseDataUrl(EXAMPLE);
+const hack = quickNDirty(EXAMPLE);
+
+function assertEquals(l, r) {
+  console.assert(l === r, "left", l, "right", r);
+}
+
+assertEquals(lib.mimeType.toString(), hack.mime);
+assertEquals(lib.body.toString("utf-8"), hack.body.toString("utf-8"));
+
+b.suite(
+  "parsing base64",
+
+  b.add("lib", () => parseDataUrl(EXAMPLE)),
+  b.add("regexp", () => quickNDirty(EXAMPLE)),
+  b.cycle(),
+  b.complete()
+);


### PR DESCRIPTION
(This is a bug report as a pull request, so I can attach code.)

I am trying to use the library to load data urls, but my data urls are rather large, and the library turns out to be a significant bottleneck; ~50% of the CPU time on an application that loads, does significant transforms on, and saves multiple reports on, data in data urls.

I've attached a benchmark vs. a terrible implementation with regexes.

For me, the attached benchmark runs like:
```
Running "parsing base64" suite...
Progress: 100%

  lib:
    6 ops/s, ±2.29%       | slowest, 99.75% slower

  regexp:
    2 384 ops/s, ±0.52%   | fastest
```

That is, the library is about 400x slower than the following code, to load your `yarn.lock`.

```
const REGEX = /^data:([^;]+);base64,(.*)/;
function quickNDirty(url) {
  const [, mime, base] = url.match(REGEX);
  return { mime, body: Buffer.from(base, "base64") };
}
```

Please consider profiling and improving the parser for this usecase.

(Yes, I'm aware that base64-url variants are a thing, but node doesn't seem to care.)